### PR TITLE
Add experience and experience types viewsets

### DIFF
--- a/trouvaille/urls.py
+++ b/trouvaille/urls.py
@@ -17,9 +17,11 @@ from django.contrib import admin
 from django.urls import path
 from django.conf.urls import include
 from rest_framework import routers
-from trouvailleapi.views import register_user, login_user
+from trouvailleapi.views import register_user, login_user, ExperienceView, ExperienceTypeView
 
 router = routers.DefaultRouter(trailing_slash=False)
+router.register(r'experiences', ExperienceView, 'experience')
+router.register(r'experienceTypes', ExperienceTypeView,'experienceTypes')
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/trouvailleapi/views/__init__.py
+++ b/trouvailleapi/views/__init__.py
@@ -1,1 +1,3 @@
 from .auth import login_user, register_user
+from .experience_view import ExperienceView
+from .experience_type_view import ExperienceTypeView

--- a/trouvailleapi/views/experience_type_view.py
+++ b/trouvailleapi/views/experience_type_view.py
@@ -1,0 +1,40 @@
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from trouvailleapi.models import ExperienceType
+
+class ExperienceTypeView(ViewSet):
+    """Viewset for experience types"""
+
+    def retrieve(self, request, pk):
+        """Handle GET requests for single experience type
+
+        Returns:
+            Response -- JSON serialized experience type
+        """
+        try:
+            experienceType = ExperienceType.objects.get(pk=pk)
+            serializer = ExperienceTypeSerializer(experienceType)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except:
+            return Response(None, status=status.HTTP_404_NOT_FOUND)
+
+
+    def list(self, request):
+        """Handle GET requests to get all experience types
+
+        Returns:
+            Response -- JSON serialized list of experience types
+        """
+
+        experienceTypes = ExperienceType.objects.all()
+        serializer = ExperienceTypeSerializer(experienceTypes, many=True)
+        return Response(serializer.data)
+
+class ExperienceTypeSerializer(serializers.ModelSerializer):
+    """JSON serializer for experiences"""
+    
+    class Meta:
+        model = ExperienceType
+        fields = ('id', 'name')

--- a/trouvailleapi/views/experience_view.py
+++ b/trouvailleapi/views/experience_view.py
@@ -1,0 +1,89 @@
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from trouvailleapi.models import Experience, ExperienceType
+
+class ExperienceView(ViewSet):
+    """Viewset for experiences"""
+
+    def retrieve(self, request, pk):
+        """Handle GET requests for single experience
+
+        Returns:
+            Response -- JSON serialized experience
+        """
+        try:
+            experience = Experience.objects.get(pk=pk)
+            serializer = ExperienceSerializer(experience)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except:
+            return Response(None, status=status.HTTP_404_NOT_FOUND)
+
+
+    def list(self, request):
+        """Handle GET requests to get all experiences
+
+        Returns:
+            Response -- JSON serialized list of experiences
+        """
+
+        experiences = Experience.objects.all()
+        serializer = ExperienceSerializer(experiences, many=True)
+        return Response(serializer.data)
+
+    def create(self, request):
+        """Handle POST operations for an experience
+
+        Returns
+            Response -- JSON serialized experience instance
+        """
+        experience_type = ExperienceType.objects.get(pk=request.data["experienceTypeId"])
+
+        experience = Experience.objects.create(
+            title = request.data["title"],
+            address = request.data["address"],
+            website_url = request.data["websiteUrl"],
+            experience_type = experience_type
+        )
+        serializer = ExperienceSerializer(experience)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def update(self, request, pk):
+        """Handle PUT requests for an experience
+
+        Returns:
+            Response -- Empty body with 204 status code
+        """
+
+        experience = Experience.objects.get(pk=pk)
+        experience.title = request.data["title"]
+        experience.address = request.data["address"]
+        experience.website_url = request.data["websiteUrl"]
+
+        experience_type = ExperienceType.objects.get(pk=request.data["experienceTypeId"])
+        experience.experience_type = experience_type
+        experience.save()
+
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+    def destroy(self, request, pk):
+        experience = Experience.objects.get(pk=pk)
+        experience.delete()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+        
+class ExperienceTypeSerializer(serializers.ModelSerializer):
+    """JSON serializer for experiences"""
+
+    class Meta:
+        model = ExperienceType
+        fields = ('id', 'name')
+
+class ExperienceSerializer(serializers.ModelSerializer):
+    """JSON serializer for experiences"""
+
+    experience_type = ExperienceTypeSerializer(many=False)
+    
+    class Meta:
+        model = Experience
+        fields = ('id', 'title', 'address', 'website_url', 'experience_type')


### PR DESCRIPTION
### Description
- Added routes for experiences and experience types to `urls.py`
- Created a class for experience views
  - Defined retrieve, list, create, update and destroy actions
  - Created classes for experience and experience type serializers
    - Expanded the experience type object on the experience response
- Created a class for experience views
  - Defined retrieve and list actions
  - Created a class for an experience type serializer
- Imported both views into `__init__.py` in the views folder

### Tests
- Tested by making the following fetch calls in Postman:
   _Added authorization header with value of 'Token eaa3b22db8f4ab559431f68cd4f021ef20d2a3d6'_

  **Experiences**
    - GET request to http://localhost:8000/experiences
    - GET request to http://localhost:8000/experiences/1
    - POST request to http://localhost:8000/experiences with raw body:
       ```
         {
             "title": "Leavenworth Coffee Roasters",
             "address": "894 US Hwy 2 STE A, Leavenworth, WA 98826",
             "websiteUrl": "https://www.leavenworthcoffeeroasters.com/",
             "experienceTypeId": 4
         }
       ```
    - PUT request to http://localhost:8000/experiences with raw body:
       ```
         {
             "title": "TEST Leavenworth Coffee Roasters",
             "address": "TEST 894 US Hwy 2 STE A, Leavenworth, WA 98826",
             "websiteUrl": "https://www.leavenworthcoffeeroasters.com/test",
             "experienceTypeId": 2
         }
       ```
    - DELETE request to http://localhost:8000/experiences/7
  
  **Experience Types**
    - GET request to http://localhost:8000/experience_types
    - GET request to http://localhost:8000/experience_types/1