### PR TITLE
Add destination viewset

### DIFF
--- a/trouvaille/urls.py
+++ b/trouvaille/urls.py
@@ -17,11 +17,12 @@ from django.contrib import admin
 from django.urls import path
 from django.conf.urls import include
 from rest_framework import routers
-from trouvailleapi.views import register_user, login_user, ExperienceView, ExperienceTypeView
+from trouvailleapi.views import register_user, login_user, ExperienceView, ExperienceTypeView, DestinationView
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'experiences', ExperienceView, 'experience')
 router.register(r'experienceTypes', ExperienceTypeView,'experienceTypes')
+router.register(r'destinations', DestinationView,'destination')
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/trouvailleapi/views/__init__.py
+++ b/trouvailleapi/views/__init__.py
@@ -1,3 +1,4 @@
 from .auth import login_user, register_user
 from .experience_view import ExperienceView
 from .experience_type_view import ExperienceTypeView
+from .destination_view import DestinationView

--- a/trouvailleapi/views/destination_view.py
+++ b/trouvailleapi/views/destination_view.py
@@ -1,0 +1,77 @@
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from trouvailleapi.models import Destination
+
+class DestinationView(ViewSet):
+    """Viewset for destinations"""
+
+    def retrieve(self, request, pk):
+        """Handle GET requests for single destination
+
+        Returns:
+            Response -- JSON serialized destination
+        """
+        try:
+            destination = Destination.objects.get(pk=pk)
+            serializer = DestinationSerializer(destination)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except:
+            return Response(None, status=status.HTTP_404_NOT_FOUND)
+
+
+    def list(self, request):
+        """Handle GET requests to get all destinations
+
+        Returns:
+            Response -- JSON serialized list of destinations
+        """
+
+        destinations = Destination.objects.all()
+        serializer = DestinationSerializer(destinations, many=True)
+        return Response(serializer.data)
+
+    def create(self, request):
+        """Handle POST operations for an destination
+
+        Returns
+            Response -- JSON serialized destination instance
+        """
+
+        destination = Destination.objects.create(
+            city = request.data["city"],
+            state = request.data["state"],
+            country = request.data["country"]
+        )
+        serializer = DestinationSerializer(destination)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def update(self, request, pk):
+        """Handle PUT requests for an destination
+
+        Returns:
+            Response -- Empty body with 204 status code
+        """
+
+        destination = Destination.objects.get(pk=pk)
+        destination.city = request.data["city"]
+        destination.state = request.data["state"]
+        destination.country = request.data["country"]
+
+        destination.save()
+
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+    def destroy(self, request, pk):
+        destination = Destination.objects.get(pk=pk)
+        destination.delete()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+
+class DestinationSerializer(serializers.ModelSerializer):
+    """JSON serializer for destinations"""
+    
+    class Meta:
+        model = Destination
+        fields = ('id', 'city', 'state', 'country')


### PR DESCRIPTION
### Description
- Added route for destinations to `urls.py`
- Created a class for destination views
  - Defined retrieve, list, create, update and destroy actions
  - Created a class for an destination serializer
- Imported view into `__init__.py` in the views folder

### Tests
- Tested by making the following fetch calls in Postman:
   _Added authorization header with value of 'Token eaa3b22db8f4ab559431f68cd4f021ef20d2a3d6'_

    - GET request to http://localhost:8000/destinations
    - GET request to http://localhost:8000/destinations/1
    - POST request to http://localhost:8000/destinations with raw body:
       ```
         {
             "city": "Portland",
             "state": "Maine",
             "country": "US"
         }
       ```
    - PUT request to http://localhost:8000/destinations with raw body:
       ```
         {
             "city": "Bar Harbor",
             "state": "Maine",
             "country": "US"
         }
       ```
    - DELETE request to http://localhost:8000/destinations/6