### PR TITLE
Add authorized traveler response

### DIFF
--- a/trouvailleapi/views/traveler_view.py
+++ b/trouvailleapi/views/traveler_view.py
@@ -14,7 +14,11 @@ class TravelerView(ViewSet):
             Response -- JSON serialized traveler
         """
         try:
-            traveler = Traveler.objects.get(pk=pk)
+            if pk == 'auth':
+                traveler = Traveler.objects.get(user=request.auth.user)
+            else:
+                traveler = Traveler.objects.get(pk=pk)
+                
             serializer = TravelerSerializer(traveler)
             return Response(serializer.data, status=status.HTTP_200_OK)
         except:


### PR DESCRIPTION
### Description
- Added conditional to check for 'auth' in a retrieve request and to return the currently authorized traveler if so

### Tests
- Tested by making the following fetch call in Postman:
   _Added authorization header with value of 'Token eaa3b22db8f4ab559431f68cd4f021ef20d2a3d6'_

    - GET request to http://localhost:8000/travelers/auth