### PR TITLE
Update trip modified date

### DIFF
--- a/trouvailleapi/views/trip_view.py
+++ b/trouvailleapi/views/trip_view.py
@@ -2,6 +2,7 @@ from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers, status
+from datetime import datetime
 from trouvailleapi.models import Trip, Traveler, Style, Season, Duration, Experience, Destination
 
 class TripView(ViewSet):
@@ -71,7 +72,7 @@ class TripView(ViewSet):
         trip.is_draft = request.data["isDraft"]
         trip.is_upcoming = request.data["isUpcoming"]
         trip.is_private = request.data["isPrivate"]
-        trip.modified_date = request.data["modifiedDate"]
+        trip.modified_date = datetime.today()
 
         traveler = Traveler.objects.get(pk=request.data["travelerId"])
         style = Style.objects.get(pk=request.data["styleId"])


### PR DESCRIPTION
### Description
- Updated the `modified_date` field on trips to be set as the current date and time when a trip is modified

### Tests
- Tested by making the following fetch call in Postman:
    _Added an Authorization header with a value of 'Token eaa3b22db8f4ab559431f68cd4f021ef20d2a3d6'_

  - PUT request to http://localhost:8000/trips with raw body:
     ```
       {
           "title": "Ski Trip TEST",
           "summary": "Ski the slopes in the Wasatch Mountains TEST",
           "styleId": 3,
           "seasonId": 2,
           "durationId": 2,
           "isDraft": false,
           "isUpcoming": false,
           "isPrivate": false
       }
     ```