### PR TITLE
Update permissions for public views

### DIFF
--- a/trouvailleapi/views/destination_view.py
+++ b/trouvailleapi/views/destination_view.py
@@ -3,9 +3,25 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers, status
 from trouvailleapi.models import Destination
+from rest_framework import permissions
+from rest_framework.decorators import api_view, permission_classes
+
+
+class DestinationPermission(permissions.BasePermission):
+    """Custom permissions for destination view"""
+
+    def has_permission(self, request, view):
+        if view.action in ['list', 'retrieve']:
+            return True
+        elif view.action in ['create', 'update', 'destroy']:
+            return request.auth is not None
+        else:
+            return False
 
 class DestinationView(ViewSet):
     """Viewset for destinations"""
+
+    permission_classes = [DestinationPermission]
 
     def retrieve(self, request, pk):
         """Handle GET requests for single destination

--- a/trouvailleapi/views/experience_view.py
+++ b/trouvailleapi/views/experience_view.py
@@ -3,9 +3,25 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers, status
 from trouvailleapi.models import Experience, ExperienceType
+from rest_framework import permissions
+from rest_framework.decorators import api_view, permission_classes
+
+
+class ExperiencePermission(permissions.BasePermission):
+    """Custom permissions for experience view"""
+
+    def has_permission(self, request, view):
+        if view.action in ['list', 'retrieve']:
+            return True
+        elif view.action in ['create', 'update', 'destroy']:
+            return request.auth is not None
+        else:
+            return False
 
 class ExperienceView(ViewSet):
     """Viewset for experiences"""
+
+    permission_classes = [ExperiencePermission]
 
     def retrieve(self, request, pk):
         """Handle GET requests for single experience

--- a/trouvailleapi/views/traveler_view.py
+++ b/trouvailleapi/views/traveler_view.py
@@ -3,9 +3,25 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers, status
 from trouvailleapi.models import Traveler
+from rest_framework import permissions
+from rest_framework.decorators import api_view, permission_classes
+
+
+class TravelerPermission(permissions.BasePermission):
+    """Custom permissions for traveler view"""
+
+    def has_permission(self, request, view):
+        if view.action in ['list']:
+            return True
+        elif view.action in ['retrieve', 'create', 'update', 'destroy']:
+            return request.auth is not None
+        else:
+            return False
 
 class TravelerView(ViewSet):
     """Viewset for travelers"""
+
+    permission_classes = [TravelerPermission]
 
     def retrieve(self, request, pk):
         """Handle GET requests for single traveler

--- a/trouvailleapi/views/trip_view.py
+++ b/trouvailleapi/views/trip_view.py
@@ -6,9 +6,25 @@ from django.utils import timezone
 from datetime import datetime
 from rest_framework.decorators import action
 from trouvailleapi.models import Trip, Traveler, Style, Season, Duration, Experience, Destination, ExperienceType
+from rest_framework import permissions
+from rest_framework.decorators import api_view, permission_classes
+
+
+class TripPermission(permissions.BasePermission):
+    """Custom permissions for destination view"""
+
+    def has_permission(self, request, view):
+        if view.action in ['list']:
+            return True
+        elif view.action in ['retrieve', 'create', 'update', 'destroy']:
+            return request.auth is not None
+        else:
+            return False
 
 class TripView(ViewSet):
     """Viewset for trips"""
+
+    permission_classes = [TripPermission]
 
     def retrieve(self, request, pk):
         """Handle GET requests for single trip
@@ -16,6 +32,7 @@ class TripView(ViewSet):
         Returns:
             Response -- JSON serialized trip
         """
+
         try:
             trip = Trip.objects.get(pk=pk)
             serializer = TripSerializer(trip)


### PR DESCRIPTION
### Descriptions
- Updated permissions so that authorization is not required for:
  - List and retrieve actions for destinations
  - List and retrieve actions for experiences
  - List action for travelers
  - List action for trips

### Tests
- Tested in browser by logging in and navigating to:
  -  http://localhost:3000/destinations
  - http://localhost:3000/experiences
  - http://localhost:3000/trips
  - http://localhost:3000/trip/{tripId}
  - http://localhost:3000/travelers
  - http://localhost:3000/travelers/{travelerId}
- Tested in browser by logging out and navigating to:
  -  http://localhost:3000/destinations
  - http://localhost:3000/experiences
  - http://localhost:3000/trips
  - http://localhost:3000/trip/{tripId}
  - http://localhost:3000/travelers
  - http://localhost:3000/travelers/{travelerId}