### PR TITLE
Add trip property to designate ownership

### DIFF
--- a/trouvailleapi/models/trip.py
+++ b/trouvailleapi/models/trip.py
@@ -14,3 +14,11 @@ class Trip(models.Model):
     modified_date = models.DateTimeField()
     experiences = models.ManyToManyField('Experience', through='TripExperience')
     destinations = models.ManyToManyField('Destination', through='TripDestination') 
+
+    @property
+    def my_trip(self):
+        return self.__my_trip
+
+    @my_trip.setter
+    def my_trip(self, value):
+        self.__my_trip = value

--- a/trouvailleapi/views/trip_view.py
+++ b/trouvailleapi/views/trip_view.py
@@ -35,6 +35,11 @@ class TripView(ViewSet):
 
         try:
             trip = Trip.objects.get(pk=pk)
+            auth_user = Traveler.objects.get(user=request.auth.user)
+            if  trip.traveler.id == auth_user.id:
+                trip.my_trip = True
+            else:
+                trip.my_trip = False
             serializer = TripSerializer(trip)
             return Response(serializer.data, status=status.HTTP_200_OK)
         except:
@@ -197,4 +202,4 @@ class TripSerializer(serializers.ModelSerializer):
     
     class Meta:
         model = Trip
-        fields = ('id', 'title', 'summary', 'traveler', 'style', 'season', 'duration', 'is_draft', 'is_upcoming', 'is_private', 'modified_date', 'experiences', 'destinations')
+        fields = ('id', 'title', 'summary', 'traveler', 'style', 'season', 'duration', 'is_draft', 'is_upcoming', 'is_private', 'modified_date', 'experiences', 'destinations', 'my_trip')


### PR DESCRIPTION
### Description
- Added a property decorator to the trip model
- Added a conditional to the trip retrieve action to check whether or not the authenticated user created the trip
  - Sets the value of the my_trip field accordingly
- Add the my_trip field to the trip serializer

### Tests
- Tested by making the following fetch calls in Postman:
    _Added an Authorization header with a value of 'Token eaa3b22db8f4ab559431f68cd4f021ef20d2a3d6' for all fetch calls_

  - GET request to http://localhost:8000/trips/2 and checked that my_trip value was true
  - GET request to http://localhost:8000/trips/13 and checked that my_trip value was false